### PR TITLE
Kubernetes intro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+kubernetes-intro/web/.dockerignore
+kubernetes-intro/web/package*
+kubernetes-intro/web/server.json

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Neodim5 Platform repository
 * Добавил в pod init контейнер, генерирующий страницу index.html
 * Проверил работоспособность web сервера с помощью kubectl port-forward
 * Hipster Shop frontend
-* Соберал собственный образ для frontend (используя готовый Dockerfile)
-* Поместите собранный образ на Docker Hub (neodim5/hipster-frontend)
+* Собрал собственный образ для frontend (используя готовый Dockerfile)
+* Поместил собранный образ на Docker Hub (neodim5/hipster-frontend)
 * Попробовал использовать ad-hoc режим и возможности Kubectl для создания ресурсов
 * Выяснил причину, по которой pod frontend находится в статусе Error. Описание в PR.
 * Разобраны декларативный и императивный подходы

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # Neodim5_platform
 Neodim5 Platform repository
+
+### Kubernetes-Intro "Знакомство с Kubernetes, основные понятия и архитектура"
+* Настроен Github actions для запуска тестов
+* Развернут локальный кластер kubernetes посредством minikube
+* Установлена актуальная версия kubectl
+* Разобрался почему все pod в namespace kube-system восстановились после удаления. Описание в PR.
+* Создан докерфайл запускающий web-сервер (nginx)
+* Собрал из Dockerfile образ контейнера и поместил его в публичный Container Registry Docker Hub (neodim5/kube-intro)
+* Создан под через web-pod.yaml
+* Добавил в pod init контейнер, генерирующий страницу index.html
+* Проверил работоспособность web сервера с помощью kubectl port-forward
+* Hipster Shop frontend
+* Соберал собственный образ для frontend (используя готовый Dockerfile)
+* Поместите собранный образ на Docker Hub (neodim5/hipster-frontend)
+* Попробовал использовать ad-hoc режим и возможности Kubectl для создания ресурсов
+* Выяснил причину, по которой pod frontend находится в статусе Error. Описание в PR.
+* Разобраны декларативный и императивный подходы

--- a/kubernetes-intro/README.md
+++ b/kubernetes-intro/README.md
@@ -1,0 +1,19 @@
+# Neodim5_platform
+Neodim5 Platform repository
+
+### Kubernetes-Intro "Знакомство с Kubernetes, основные понятия и архитектура"
+* Настроен Github actions для запуска тестов
+* Развернут локальный кластер kubernetes посредством minikube
+* Установлена актуальная версия kubectl
+* Разобрался почему все pod в namespace kube-system восстановились после удаления. Описание в PR.
+* Создан докерфайл запускающий web-сервер (nginx)
+* Собрал из Dockerfile образ контейнера и поместил его в публичный Container Registry Docker Hub (neodim5/kube-intro)
+* Создан под через web-pod.yaml
+* Добавил в pod init контейнер, генерирующий страницу index.html
+* Проверил работоспособность web сервера с помощью kubectl port-forward
+* Hipster Shop frontend
+* Собрал собственный образ для frontend (используя готовый Dockerfile)
+* Поместил собранный образ на Docker Hub (neodim5/hipster-frontend)
+* Попробовал использовать ad-hoc режим и возможности Kubectl для создания ресурсов
+* Выяснил причину, по которой pod frontend находится в статусе Error. Описание в PR.
+* Разобраны декларативный и императивный подходы

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -27,6 +27,8 @@ spec:
         value: "checkoutservice:5050"
       - name: AD_SERVICE_ADDR
         value: "adservice:9555"
+      - name: ENABLE_PROFILER
+        value: "0"
   dnsPolicy: ClusterFirst
   restartPolicy: Never
 status: {}

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -11,20 +11,22 @@ spec:
     name: frontend
     resources: {}
     env:
-     - name: PRODUCT_CATALOG_SERVICE_ADDR
-       value: "PRODUCT_CATALOG_SERVICE_ADDR:7001"
-     - name: CURRENCY_SERVICE_ADDR
-       value: "CURRENCY_SERVICE_ADDR:7002"
-     - name: CART_SERVICE_ADDR
-       value: "CART_SERVICE_ADDR:7003"
-     - name: RECOMMENDATION_SERVICE_ADDR
-       value: "RECOMMENDATION_SERVICE_ADDR:7004"
-     - name: CHECKOUT_SERVICE_ADDR
-       value: "CHECKOUT_SERVICE_ADDR:7005"
-     - name: SHIPPING_SERVICE_ADDR
-       value: "SHIPPING_SERVICE_ADDR:7006"
-     - name: AD_SERVICE_ADDR
-       value: "AD_SERVICE_ADDR:7007"
+      - name: PORT
+        value: "8080"
+      - name: PRODUCT_CATALOG_SERVICE_ADDR
+        value: "productcatalogservice:3550"
+      - name: CURRENCY_SERVICE_ADDR
+        value: "currencyservice:7000"
+      - name: CART_SERVICE_ADDR
+        value: "cartservice:7070"
+      - name: RECOMMENDATION_SERVICE_ADDR
+        value: "recommendationservice:8080"
+      - name: SHIPPING_SERVICE_ADDR
+        value: "shippingservice:50051"
+      - name: CHECKOUT_SERVICE_ADDR
+        value: "checkoutservice:5050"
+      - name: AD_SERVICE_ADDR
+        value: "adservice:9555"
   dnsPolicy: ClusterFirst
   restartPolicy: Never
 status: {}

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: neodim5/hipster-frontend:latest
+    name: frontend
+    resources: {}
+    env:
+     - name: PRODUCT_CATALOG_SERVICE_ADDR
+       value: "PRODUCT_CATALOG_SERVICE_ADDR:7001"
+     - name: CURRENCY_SERVICE_ADDR
+       value: "CURRENCY_SERVICE_ADDR:7002"
+     - name: CART_SERVICE_ADDR
+       value: "CART_SERVICE_ADDR:7003"
+     - name: RECOMMENDATION_SERVICE_ADDR
+       value: "RECOMMENDATION_SERVICE_ADDR:7004"
+     - name: CHECKOUT_SERVICE_ADDR
+       value: "CHECKOUT_SERVICE_ADDR:7005"
+     - name: SHIPPING_SERVICE_ADDR
+       value: "SHIPPING_SERVICE_ADDR:7006"
+     - name: AD_SERVICE_ADDR
+       value: "AD_SERVICE_ADDR:7007"
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -7,7 +7,7 @@ metadata:
   name: frontend
 spec:
   containers:
-  - image: neodim5/hipster-frontend:latest
+  - image: neodim5/hipster-frontend:v0.0.1
     name: frontend
     resources: {}
     env:

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -11,13 +11,6 @@ spec:
        volumeMounts:
          - name: app
            mountPath: /app
-   initContainers:
-     - name: init
-       image: busybox:1.34.0
-       command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
-       volumeMounts:
-         - name: app
-           mountPath: /app
    volumes:
      - name: app
        emptyDir: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
    containers:
      - name: web
-       image: neodim5/kube-intro:latest
+       image: neodim5/kube-intro:v0.0.1
        volumeMounts:
          - name: app
            mountPath: /app

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -11,6 +11,13 @@ spec:
        volumeMounts:
          - name: app
            mountPath: /app
+   initContainers:
+     - name: init
+       image: busybox:1.36
+       command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+       volumeMounts:
+         - name: app
+           mountPath: /app
    volumes:
      - name: app
        emptyDir: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels:
+    key: app
+spec:
+   containers:
+     - name: web
+       image: neodim5/kube-intro:latest
+       volumeMounts:
+         - name: app
+           mountPath: /app
+   initContainers:
+     - name: init
+       image: busybox:1.34.0
+       command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+       volumeMounts:
+         - name: app
+           mountPath: /app
+   volumes:
+     - name: app
+       emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,24 @@
+FROM nginx:stable
+
+RUN mkdir /app
+
+WORKDIR /app
+
+RUN usermod -u 1001 nginx \
+  && groupmod -g 1001 nginx
+RUN chown -R nginx:nginx /app && chmod -R 755 /app && \
+        chown -R nginx:nginx /var/cache/nginx && \
+        chown -R nginx:nginx /var/log/nginx && \
+        chown -R nginx:nginx /etc/nginx/conf.d
+RUN touch /var/run/nginx.pid && \
+        chown -R nginx:nginx /var/run/nginx.pid
+
+USER nginx
+
+RUN sed -i 's/80/8000/g' /etc/nginx/conf.d/default.conf
+
+RUN sed -i 's/\/usr\/share\/nginx\/html/\/app/g' /etc/nginx/conf.d/default.conf
+
+EXPOSE 8000
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -20,5 +20,5 @@ RUN sed -i 's/80/8000/g' /etc/nginx/conf.d/default.conf
 RUN sed -i 's/\/usr\/share\/nginx\/html/\/app/g' /etc/nginx/conf.d/default.conf
 
 EXPOSE 8000
-
+COPY *.html ./
 CMD ["nginx", "-g", "daemon off;"]

--- a/kubernetes-intro/web/index.html
+++ b/kubernetes-intro/web/index.html
@@ -1,0 +1,4 @@
+<html>
+    <head>HW 1</head>
+    <body>Test for HW1</body>
+</html>


### PR DESCRIPTION
# Выполнено ДЗ №1

 - [v] Основное ДЗ
 - [v] Задание со *

## В процессе сделано:
  - Настроен Github actions для запуска тестов
  - Развернут локальный кластер kubernetes посредством minikube
  - Установлена актуальная версия kubectl
  -  Разобрался почему все pod в namespace kube-system восстановились после удаления.
  - Создан докерфайл запускающий web-сервер (nginx)
  - Собрал из Dockerfile образ контейнера и поместил его в публичный Container Registry Docker Hub (neodim5/kube-intro)
  - Создан под через web-pod.yaml
  - Добавил в pod init контейнер, генерирующий страницу index.html
  - Проверил работоспособность web сервера с помощью kubectl port-forward
  - Hipster Shop frontend
  - Собрал собственный образ для frontend (используя готовый Dockerfile)
  - Поместите собранный образ на Docker Hub (neodim5/hipster-frontend)
  - Попробовал использовать ad-hoc режим и возможности Kubectl для создания ресурсов
  - Выяснил причину, по которой pod frontend находится в статусе Error.

  + # Пункт 1. Почему все pod в namespace kube-system восстановились после удаления

Все pods в namespace kube-system востановились потому что их пересоздал kubelet systemd демон работающий на самом хосте (master-node).
Исключения из списка составляют kube-proxy и coredns. kube-proxy - компонент worker-node и его подниает deamonSet kube-proxy на worker-node. Coredns - компонент master-node запускаемый через одноименную ReplicaSet.
```
neodim@otus:~$ kubectl get po -n kube-system
NAME                               READY   STATUS    RESTARTS   AGE
coredns-5d78c9869d-9bvp4           1/1     Running   0          75m
etcd-minikube                      1/1     Running   1          75m
kube-apiserver-minikube            1/1     Running   1          75m
kube-controller-manager-minikube   1/1     Running   1          75m
kube-proxy-h5vhq                   1/1     Running   0          75m
kube-scheduler-minikube            1/1     Running   1          75m
metrics-server-7746886d4f-tqwdn    1/1     Running   0          75m
```

### kube-proxy - компонент worker-node
```
neodim@otus:~$ kubectl get ds -n kube-system
NAME         DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
kube-proxy   1         1         1       1            1           kubernetes.io/os=linux   4h12m
```
deamonSet kube-proxy подниает pod kube-proxy-h5vhq 

### coredns - компонент master-node через ReplicaSet
```
neodim@otus:~$ kubectl get rs -n kube-system
NAME                        DESIRED   CURRENT   READY   AGE
coredns-5d78c9869d          1         1         1       4h13m
```
ReplicaSet coredns-5d78c9869d подниает pod coredns-5d78c9869d-9bvp4

### kube-apiserver-minikube - компонент master-node
```
neodim@otus:~$ kubectl describe pod kube-apiserver-minikube -n kube-system | grep  Control
Controlled By:  Node/minikube
```
Упраляет сама нода minikube

### etcd-minikube - компонент master-node
```
neodim@otus:~$ kubectl describe pod etcd-minikube -n kube-system | grep  Control
Controlled By:  Node/minikube
```
Упраляет сама нода minikube

### kube-controller-manager-minikube - компонент master-node
```
neodim@otus:~$ kubectl describe pod kube-controller-manager-minikube -n kube-system | grep  Control
Controlled By:  Node/minikube
```
Упраляет сама нода minikube

### kube-scheduler-minikube - компонент master-node
```
neodim@otus:~$ kubectl describe pod kube-scheduler-minikube -n kube-system | grep  Control
Controlled By:  Node/minikube
```
Упраляет сама нода minikube

### metrics-server
```
neodim@otus:~$ kubectl describe pod metrics-server -n kube-system | grep  Control
Controlled By:  ReplicaSet/metrics-server-7746886d4f
```
ReplicaSet metrics-server-7746886d4f подниает pod metrics-server-7746886d4f-tqwdn


  + # Пункт 2. Выяснил причину, по которой pod frontend находится в статусе Error.
```
neodim@otus:~/kube_intro$ kubectl logs frontend
{"message":"Tracing disabled.","severity":"info","timestamp":"2023-09-09T16:11:41.290227955Z"}
{"message":"Profiling disabled.","severity":"info","timestamp":"2023-09-09T16:11:41.290334296Z"}
panic: environment variable "PRODUCT_CATALOG_SERVICE_ADDR" not set
```
На основание этой ошибки и подсказки на манифест frontend'а, понял что не хватает описание переменных. Былыи добавлены необходимые для запуска пода переменные.
```
    env:
      - name: PORT
        value: "8080"
      - name: PRODUCT_CATALOG_SERVICE_ADDR
        value: "productcatalogservice:3550"
      - name: CURRENCY_SERVICE_ADDR
        value: "currencyservice:7000"
      - name: CART_SERVICE_ADDR
        value: "cartservice:7070"
      - name: RECOMMENDATION_SERVICE_ADDR
        value: "recommendationservice:8080"
      - name: SHIPPING_SERVICE_ADDR
        value: "shippingservice:50051"
      - name: CHECKOUT_SERVICE_ADDR
        value: "checkoutservice:5050"
      - name: AD_SERVICE_ADDR
        value: "adservice:9555"
```
После под поднялся без ошибок.

## Как запустить проект:
   - Выполнить команду kubectl apply -f web-pod.yaml в директории kubernetes-intro
   - Потом kubectl port-forward --address 0.0.0.0 pod/web 8000:8000
   - Выполнить команду kubectl apply -f frontend-pod-healthy.yaml в директории kubernetes-intro

## Как проверить работоспособность:
 - Перейти по ссылке http://localhost:8000/index.html
 - Выполнить kubectl get pods frontend - под должен быть в running

## PR checklist:
 - [v] Выставлен label с темой домашнего задания
